### PR TITLE
Make provider-alibaba container run as non-root

### DIFF
--- a/cluster/images/provider-alibaba/Dockerfile
+++ b/cluster/images/provider-alibaba/Dockerfile
@@ -9,4 +9,5 @@ ADD provider /usr/local/bin/crossplane-alibaba-provider
 COPY package /
 
 EXPOSE 8080
+USER 1001
 ENTRYPOINT ["crossplane-alibaba-provider"]

--- a/config/package/manifests/install.yaml
+++ b/config/package/manifests/install.yaml
@@ -17,7 +17,6 @@ spec:
     spec:
       containers:
       - name: "provider-alibaba-controller"
-        image: "crossplane/provider-alibaba:master"
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION


Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Crossplane refuses containers that run as root by default. provider-alibaba does not require root access so it should run as non-root by default.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.
- [ ] Updated the [package resources documentation] to include any new managed resources or classes.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-alibaba/blob/master/config/package/manifests/app.yaml
[package resources documentation]: https://github.com/crossplane/provider-alibaba/blob/master/config/package/manifests/resources
