### PR TITLE
fix: handle sdk ServerError InvalidDBInstanceId.NotFound when instance not present.

### DIFF
--- a/pkg/clients/rds/rds.go
+++ b/pkg/clients/rds/rds.go
@@ -91,7 +91,7 @@ func (c *client) DescribeDBInstance(id string) (*DBInstance, error) {
 
 	response, err := c.rdsCli.DescribeDBInstances(request)
 	if err != nil {
-		return nil, errorConvert(err)
+		return nil, err
 	}
 	if len(response.Items.DBInstance) == 0 {
 		return nil, ErrDBInstanceNotFound
@@ -189,13 +189,8 @@ func IsErrorNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	return errors.Is(err, ErrDBInstanceNotFound)
-}
-
-// errorConvert handle Server Error and covert error type
-func errorConvert(err error) error {
 	if e, ok := err.(*sdkErrors.ServerError); ok && e.ErrorCode() == ErrCodeInstanceNotFound {
-		return ErrDBInstanceNotFound
+		return true
 	}
-	return err
+	return errors.Is(err, ErrDBInstanceNotFound)
 }

--- a/pkg/clients/rds/rds.go
+++ b/pkg/clients/rds/rds.go
@@ -31,6 +31,7 @@ import (
 var (
 	// ErrDBInstanceNotFound indicates DBInstance not found
 	ErrDBInstanceNotFound = errors.New("DBInstanceNotFound")
+	// ErrCodeInstanceNotFound error code of ServerError when DBInstance not found
 	ErrCodeInstanceNotFound = "InvalidDBInstanceId.NotFound"
 )
 

--- a/pkg/clients/rds/rds.go
+++ b/pkg/clients/rds/rds.go
@@ -19,8 +19,9 @@ package rds
 import (
 	"context"
 	"errors"
-	sdkErrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"time"
+
+	sdkErrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	alirds "github.com/aliyun/alibaba-cloud-sdk-go/services/rds"

--- a/pkg/clients/rds/rds.go
+++ b/pkg/clients/rds/rds.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"time"
 
-	sdkErrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
+	sdkerrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	alirds "github.com/aliyun/alibaba-cloud-sdk-go/services/rds"
@@ -189,7 +189,8 @@ func IsErrorNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	if e, ok := err.(*sdkErrors.ServerError); ok && e.ErrorCode() == ErrCodeInstanceNotFound {
+	// If instance already remove from console.  should ignore when delete instance
+	if e, ok := err.(*sdkerrors.ServerError); ok && e.ErrorCode() == ErrCodeInstanceNotFound {
 		return true
 	}
 	return errors.Is(err, ErrDBInstanceNotFound)

--- a/pkg/clients/rds/rds.go
+++ b/pkg/clients/rds/rds.go
@@ -19,6 +19,7 @@ package rds
 import (
 	"context"
 	"errors"
+	sdkErrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
@@ -30,6 +31,7 @@ import (
 var (
 	// ErrDBInstanceNotFound indicates DBInstance not found
 	ErrDBInstanceNotFound = errors.New("DBInstanceNotFound")
+	ErrCodeInstanceNotFound = "InvalidDBInstanceId.NotFound"
 )
 
 // Client defines RDS client operations
@@ -87,7 +89,7 @@ func (c *client) DescribeDBInstance(id string) (*DBInstance, error) {
 
 	response, err := c.rdsCli.DescribeDBInstances(request)
 	if err != nil {
-		return nil, err
+		return nil, errorConvert(err)
 	}
 	if len(response.Items.DBInstance) == 0 {
 		return nil, ErrDBInstanceNotFound
@@ -186,4 +188,12 @@ func IsErrorNotFound(err error) bool {
 		return false
 	}
 	return errors.Is(err, ErrDBInstanceNotFound)
+}
+
+// errorConvert handle Server Error and covert error type
+func errorConvert(err error) error {
+	if e, ok := err.(*sdkErrors.ServerError); ok && e.ErrorCode() == ErrCodeInstanceNotFound {
+		return ErrDBInstanceNotFound
+	}
+	return err
 }

--- a/pkg/clients/rds/rds_test.go
+++ b/pkg/clients/rds/rds_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
+
 	"github.com/crossplane/provider-alibaba/apis/database/v1alpha1"
 )
 

--- a/pkg/clients/rds/rds_test.go
+++ b/pkg/clients/rds/rds_test.go
@@ -1,8 +1,10 @@
 package rds
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/crossplane/provider-alibaba/apis/database/v1alpha1"
 )
 
@@ -10,5 +12,17 @@ func TestGenerateObservation(t *testing.T) {
 	ob := GenerateObservation(&DBInstance{Status: v1alpha1.RDSInstanceStateRunning})
 	if ob.DBInstanceStatus != v1alpha1.RDSInstanceStateRunning {
 		t.Errorf("DBInstanceStatus: want=%v, get=%v", v1alpha1.RDSInstanceStateRunning, ob.DBInstanceStatus)
+	}
+}
+
+func TestIsErrorNotFound(t *testing.T) {
+	var response = make(map[string]string)
+	response["Code"] = ErrCodeInstanceNotFound
+
+	responseContent, _ := json.Marshal(response)
+	err := errors.NewServerError(404, string(responseContent), "comment")
+	isErrorNotFound := IsErrorNotFound(err)
+	if !isErrorNotFound {
+		t.Errorf("IsErrorNotFound: want=%v, get=%v", true, isErrorNotFound)
 	}
 }


### PR DESCRIPTION
fix: handle sdk ServerError InvalidDBInstanceId.NotFound when instance not present.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

When DB Instance is not present in RDS the DescribeDBInstances api will throw ServerError with errorMessage *InvalidDBInstanceId.NotFound*. This will broke the Observe() and Delete() Logic. The Change as follow will check the error type and content, make sure thow the right type of error.

```
func errorConvert(err error) error {
	if e, ok := err.(*sdkErrors.ServerError); ok && e.ErrorCode() == ErrCodeInstanceNotFound {
		return ErrDBInstanceNotFound
	}
	return err
}
```

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

TAB

[contribution process]: https://git.io/fj2m9
