### PR TITLE
Add FileSystemID in connection secret

### DIFF
--- a/pkg/controller/nas/nas_controller_test.go
+++ b/pkg/controller/nas/nas_controller_test.go
@@ -115,7 +115,7 @@ func TestObserve(t *testing.T) {
 				o: managed.ExternalObservation{
 					ResourceExists:    true,
 					ResourceUpToDate:  false,
-					ConnectionDetails: GetConnectionDetails(validCR)},
+					ConnectionDetails: GetConnectionDetails(pointer.StringPtr("456"), validCR)},
 				err: nil,
 			},
 		},
@@ -166,7 +166,7 @@ func TestCreate(t *testing.T) {
 			mg:     validCR,
 			want: want{
 				o: managed.ExternalCreation{
-					ConnectionDetails: GetConnectionDetails(validCR)},
+					ConnectionDetails: GetConnectionDetails(pointer.StringPtr("123456"), validCR)},
 				err: nil,
 			},
 		},


### PR DESCRIPTION
ManagedResource NASMountTarget dependents on the output of
NASFileSystem

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Add FileSystemID in connection secret as ManagedResource NASMountTarget dependents on the output of
NASFileSystem.



I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
