### PR TITLE
Use meta.GetExternalName(mg) to check whether the managed resource exists

### DIFF
--- a/pkg/controller/nas/mountpoint_controller.go
+++ b/pkg/controller/nas/mountpoint_controller.go
@@ -22,6 +22,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
@@ -124,14 +125,13 @@ func (e *mountTargetExternal) Observe(ctx context.Context, mg resource.Managed) 
 		return managed.ExternalObservation{}, errors.New(errNotNASMountTarget)
 	}
 
-	domain := cr.Status.AtProvider.MountTargetDomain
-	if domain == nil {
+	if meta.GetExternalName(mg) == "" {
 		return managed.ExternalObservation{
 			ResourceExists: false,
 		}, nil
 	}
 
-	mountTarget, err := e.ExternalClient.DescribeMountTargets(cr.Spec.ForProvider.FileSystemID, domain)
+	mountTarget, err := e.ExternalClient.DescribeMountTargets(cr.Spec.ForProvider.FileSystemID, cr.Status.AtProvider.MountTargetDomain)
 	if err != nil {
 		// Managed resource `NASMountTarget` is special, the identifier of if `name` is different to the cloud resource identifier `MountTargetDomain`
 		if nasclient.IsMountTargetNotFoundError(err) {

--- a/pkg/controller/nas/nas_controller.go
+++ b/pkg/controller/nas/nas_controller.go
@@ -22,6 +22,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
@@ -133,7 +134,7 @@ func (e *External) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	fsID := cr.Status.AtProvider.FileSystemID
-	if fsID == "" {
+	if meta.GetExternalName(mg) == "" {
 		return managed.ExternalObservation{
 			ResourceExists: false,
 		}, nil

--- a/pkg/controller/slb/slb_controller.go
+++ b/pkg/controller/slb/slb_controller.go
@@ -22,6 +22,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
@@ -127,14 +128,13 @@ func (e *External) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.New(errNotCLB)
 	}
 
-	lbID := cr.Status.AtProvider.LoadBalancerID
-	if lbID == nil {
+	if meta.GetExternalName(mg) == "" {
 		return managed.ExternalObservation{
 			ResourceExists: false,
 		}, nil
 	}
 
-	slb, err := e.ExternalClient.DescribeLoadBalancers(cr.Spec.ForProvider.Region, lbID, cr.Spec.ForProvider.VpcID,
+	slb, err := e.ExternalClient.DescribeLoadBalancers(cr.Spec.ForProvider.Region, cr.Status.AtProvider.LoadBalancerID, cr.Spec.ForProvider.VpcID,
 		cr.Spec.ForProvider.VSwitchID)
 	if err != nil {
 		return managed.ExternalObservation{ResourceExists: false}, errors.Wrap(err, errFailedToDescribeSLB)


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
If we don't use meta.GetExternalName(mg) as the identifier when
the managed resource exists, or there will be more than one external
cloud resources are created.



I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
