### PR TITLE
Upgrade ProviderConfig version to v1beta1

### DIFF
--- a/pkg/controller/sls/index_controller.go
+++ b/pkg/controller/sls/index_controller.go
@@ -72,7 +72,7 @@ type indexConnector struct {
 func (c *indexConnector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
 	cr, ok := mg.(*aliv1alpha1.LogstoreIndex)
 	if !ok {
-		return nil, errors.New(errNotLogtail)
+		return nil, errors.New(errNotIndex)
 	}
 
 	info, err := util.PrepareClient(ctx, mg, cr, c.client, c.usage, cr.Spec.ProviderConfigReference.Name)

--- a/pkg/controller/sls/machineGroupBinding_controller.go
+++ b/pkg/controller/sls/machineGroupBinding_controller.go
@@ -71,7 +71,7 @@ type machineGroupBindingConnector struct {
 func (c *machineGroupBindingConnector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
 	cr, ok := mg.(*aliv1alpha1.MachineGroupBinding)
 	if !ok {
-		return nil, errors.New(errNotLogtail)
+		return nil, errors.New(errNotMachineGroupBinding)
 	}
 
 	info, err := util.PrepareClient(ctx, mg, cr, c.client, c.usage, cr.Spec.ProviderConfigReference.Name)

--- a/pkg/controller/sls/machineGroupBinding_controller.go
+++ b/pkg/controller/sls/machineGroupBinding_controller.go
@@ -27,13 +27,11 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	aliv1alpha1 "github.com/crossplane/provider-alibaba/apis/sls/v1alpha1"
-	"github.com/crossplane/provider-alibaba/apis/v1alpha1"
+	"github.com/crossplane/provider-alibaba/apis/v1beta1"
 	slsclient "github.com/crossplane/provider-alibaba/pkg/clients/sls"
 	"github.com/crossplane/provider-alibaba/pkg/util"
 )
@@ -57,7 +55,7 @@ func SetupMachineGroupBinding(mgr ctrl.Manager, l logging.Logger) error {
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 			managed.WithExternalConnecter(&machineGroupBindingConnector{
 				client:      mgr.GetClient(),
-				usage:       resource.NewProviderConfigUsageTracker(mgr.GetClient(), &v1alpha1.ProviderConfigUsage{}),
+				usage:       resource.NewProviderConfigUsageTracker(mgr.GetClient(), &v1beta1.ProviderConfigUsage{}),
 				NewClientFn: slsclient.NewClient,
 			})))
 }
@@ -73,44 +71,16 @@ type machineGroupBindingConnector struct {
 func (c *machineGroupBindingConnector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
 	cr, ok := mg.(*aliv1alpha1.MachineGroupBinding)
 	if !ok {
-		return nil, errors.New(errNotMachineGroupBinding)
+		return nil, errors.New(errNotLogtail)
 	}
 
-	var (
-		sel    *xpv1.SecretKeySelector
-		region string
-	)
-
-	switch {
-	case cr.GetProviderConfigReference() != nil:
-		if err := c.usage.Track(ctx, mg); err != nil {
-			return nil, errors.Wrap(err, errTrackUsage)
-		}
-
-		pc := &v1alpha1.ProviderConfig{}
-		if err := c.client.Get(ctx, types.NamespacedName{Name: cr.Spec.ProviderConfigReference.Name}, pc); err != nil {
-			return nil, errors.Wrap(err, errGetProviderConfig)
-		}
-		if s := pc.Spec.Credentials.Source; s != xpv1.CredentialsSourceSecret {
-			return nil, errors.Errorf(errFmtUnsupportedCredSource, s)
-		}
-		sel = pc.Spec.Credentials.SecretRef
-		region = pc.Spec.Region
-	default:
-		return nil, errors.New(errNoProvider)
+	info, err := util.PrepareClient(ctx, mg, cr, c.client, c.usage, cr.Spec.ProviderConfigReference.Name)
+	if err != nil {
+		return nil, err
 	}
 
-	if sel == nil {
-		return nil, errors.New(errNoConnectionSecret)
-	}
-
-	s := &corev1.Secret{}
-	nn := types.NamespacedName{Namespace: sel.Namespace, Name: sel.Name}
-	if err := c.client.Get(ctx, nn, s); err != nil {
-		return nil, errors.Wrap(err, errGetConnectionSecret)
-	}
-
-	slsClient := c.NewClientFn(string(s.Data[util.AccessKeyID]), string(s.Data[util.AccessKeySecret]), string(s.Data[util.SecurityToken]), region)
+	slsClient := c.NewClientFn(info.AccessKeyID, info.AccessKeySecret,
+		info.SecurityToken, info.Region)
 	return &machineGroupBindingExternal{client: slsClient}, nil
 }
 

--- a/pkg/controller/sls/machineGroup_controller.go
+++ b/pkg/controller/sls/machineGroup_controller.go
@@ -26,13 +26,11 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	aliv1alpha1 "github.com/crossplane/provider-alibaba/apis/sls/v1alpha1"
-	"github.com/crossplane/provider-alibaba/apis/v1alpha1"
+	"github.com/crossplane/provider-alibaba/apis/v1beta1"
 	slsclient "github.com/crossplane/provider-alibaba/pkg/clients/sls"
 	"github.com/crossplane/provider-alibaba/pkg/util"
 )
@@ -56,7 +54,7 @@ func SetupMachineGroup(mgr ctrl.Manager, l logging.Logger) error {
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 			managed.WithExternalConnecter(&machineGroupConnector{
 				client:      mgr.GetClient(),
-				usage:       resource.NewProviderConfigUsageTracker(mgr.GetClient(), &v1alpha1.ProviderConfigUsage{}),
+				usage:       resource.NewProviderConfigUsageTracker(mgr.GetClient(), &v1beta1.ProviderConfigUsage{}),
 				NewClientFn: slsclient.NewClient,
 			})))
 }
@@ -72,44 +70,16 @@ type machineGroupConnector struct {
 func (c *machineGroupConnector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
 	cr, ok := mg.(*aliv1alpha1.MachineGroup)
 	if !ok {
-		return nil, errors.New(errNotMachineGroup)
+		return nil, errors.New(errNotLogtail)
 	}
 
-	var (
-		sel    *xpv1.SecretKeySelector
-		region string
-	)
-
-	switch {
-	case cr.GetProviderConfigReference() != nil:
-		if err := c.usage.Track(ctx, mg); err != nil {
-			return nil, errors.Wrap(err, errTrackUsage)
-		}
-
-		pc := &v1alpha1.ProviderConfig{}
-		if err := c.client.Get(ctx, types.NamespacedName{Name: cr.Spec.ProviderConfigReference.Name}, pc); err != nil {
-			return nil, errors.Wrap(err, errGetProviderConfig)
-		}
-		if s := pc.Spec.Credentials.Source; s != xpv1.CredentialsSourceSecret {
-			return nil, errors.Errorf(errFmtUnsupportedCredSource, s)
-		}
-		sel = pc.Spec.Credentials.SecretRef
-		region = pc.Spec.Region
-	default:
-		return nil, errors.New(errNoProvider)
+	info, err := util.PrepareClient(ctx, mg, cr, c.client, c.usage, cr.Spec.ProviderConfigReference.Name)
+	if err != nil {
+		return nil, err
 	}
 
-	if sel == nil {
-		return nil, errors.New(errNoConnectionSecret)
-	}
-
-	s := &corev1.Secret{}
-	nn := types.NamespacedName{Namespace: sel.Namespace, Name: sel.Name}
-	if err := c.client.Get(ctx, nn, s); err != nil {
-		return nil, errors.Wrap(err, errGetConnectionSecret)
-	}
-
-	slsClient := c.NewClientFn(string(s.Data[util.AccessKeyID]), string(s.Data[util.AccessKeySecret]), string(s.Data[util.SecurityToken]), region)
+	slsClient := c.NewClientFn(info.AccessKeyID, info.AccessKeySecret,
+		info.SecurityToken, info.Region)
 	return &machineGroupExternal{client: slsClient}, nil
 }
 

--- a/pkg/controller/sls/machineGroup_controller.go
+++ b/pkg/controller/sls/machineGroup_controller.go
@@ -70,7 +70,7 @@ type machineGroupConnector struct {
 func (c *machineGroupConnector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
 	cr, ok := mg.(*aliv1alpha1.MachineGroup)
 	if !ok {
-		return nil, errors.New(errNotLogtail)
+		return nil, errors.New(errNotMachineGroup)
 	}
 
 	info, err := util.PrepareClient(ctx, mg, cr, c.client, c.usage, cr.Spec.ProviderConfigReference.Name)


### PR DESCRIPTION
By upgrading the version of ProviderConfig to v1beta1 can fix the
build issue and simplify the process of managed resource connection.

Fixed the issue mentioned in https://github.com/crossplane/provider-alibaba/pull/64#issuecomment-884584306

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
